### PR TITLE
Use GET /eth/v2/beacon/blocks endpoint

### DIFF
--- a/beacon/client.go
+++ b/beacon/client.go
@@ -161,7 +161,7 @@ func (c *Client) ProposerAssignments(epoch uint64) (*types.EpochProposerAssignme
 }
 
 func (c *Client) ExecutionBlockNumber(slot uint64) (uint64, error) {
-	url := fmt.Sprintf("%s/eth/v1/beacon/blocks/%d", c.endpoint, slot)
+	url := fmt.Sprintf("%s/eth/v2/beacon/blocks/%d", c.endpoint, slot)
 
 	resp, err := c.httpClient.Get(url)
 


### PR DESCRIPTION
`/eth/v1/beacon/blocks` endpoint was removed from the specification - https://github.com/ethereum/beacon-APIs/commit/0fc77b79df7e6293192cf4cd97a8d94387ea640d

This endpoint was also removed from the Prysm client - https://github.com/prysmaticlabs/prysm/commit/41d97a2a27b912fc65dbdeb741f6f09575f24784